### PR TITLE
Replace NeXT findfile directives with GNU make includes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,5 @@ $(DSTROOT):
 #
 # Include file for directory makefiles
 #
-findfile MakeInc.dir
+# Use GNU make's include directive for compatibility with non-NeXT build tools.
+include MakeInc.dir

--- a/conf/tools/Makefile
+++ b/conf/tools/Makefile
@@ -34,7 +34,8 @@ DSTROOT=$(VERSDIR)/BUILD
 #
 # Include file for directory makefiles
 #
-findfile MakeInc.dir
+# Use GNU make's include directive for compatibility with modern environments.
+include ../../MakeInc.dir
 
 #
 # Get a usable version of doconf for the installhdrs target.

--- a/conf/tools/doconf/Makefile
+++ b/conf/tools/doconf/Makefile
@@ -62,4 +62,5 @@ installhdrs:
 #
 # Include file for shell script makefiles
 #
-findfile MakeInc.csh
+# Use GNU make's include directive for compatibility with modern environments.
+include ../../../MakeInc.csh

--- a/conf/tools/newvers/Makefile
+++ b/conf/tools/newvers/Makefile
@@ -62,4 +62,5 @@ installhdrs:
 #
 # Include file for shell script makefiles
 #
-findfile MakeInc.csh
+# Use GNU make's include directive for compatibility with modern environments.
+include ../../../MakeInc.csh

--- a/src/MAKEDEV/Makefile
+++ b/src/MAKEDEV/Makefile
@@ -75,4 +75,5 @@ installhdrs:
 #
 # Include file for shell script makefiles
 #
-findfile MakeInc.csh
+# Use GNU make's include directive for compatibility with modern environments.
+include ../../MakeInc.csh

--- a/src/Makefile
+++ b/src/Makefile
@@ -43,4 +43,5 @@ SYMROOT=$(VERSDIR)/BUILD
 #
 # Include file for directory makefiles
 #
-findfile MakeInc.dir
+# Use GNU make's include directive for compatibility with modern toolchains.
+include ../MakeInc.dir


### PR DESCRIPTION
## Summary
- Replace NeXT-specific `findfile` statements with portable GNU `include` directives across build scripts.
- Document rationale for using GNU make includes to broaden compatibility.

## Testing
- `sudo apt update`
- `sudo apt install -y build-essential`
- `make kernels` *(fails: MakeInc.dir:99: target 'BUILD' given more than once in the same rule; relpath: not found; Must define DSTROOT)*

------
https://chatgpt.com/codex/tasks/task_e_689da202c98483319c92009312c818fa

## Summary by Sourcery

Replace NeXT-specific findfile directives with GNU make include directives across all build and configuration makefiles and document the compatibility rationale.

Enhancements:
- Replace findfile directives with GNU make include directives in top-level and subdirectory Makefiles for portability across modern toolchains.

Documentation:
- Add comments explaining the rationale for switching to GNU make include directives to broaden compatibility.