### PR TITLE
Replace NeXT findfile directives with GNU make includes

### DIFF
--- a/MakeInc.dir
+++ b/MakeInc.dir
@@ -33,8 +33,10 @@ ifneq "" "$(wildcard /bin/mkdirs)"
 else
   MKDIRS = /bin/mkdir -p
 endif
+PATH := $(abspath $(VERSDIR)):$(PATH)
+export PATH
 
-BUILD_DIRS= $(OBJROOT) $(SYMROOT)
+BUILD_DIRS := $(sort $(OBJROOT) $(SYMROOT))
 
 .DEFTARGET:	all
 
@@ -96,7 +98,7 @@ DSTROOT SRCROOT OBJROOT:
 		exit 1; \
 	fi
 
-$(OBJROOT) $(SYMROOT):
+$(BUILD_DIRS):
 	$(MKDIRS) $@
 
 ALWAYS:

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ VERSDIR=.
 
 OBJROOT=$(VERSDIR)/BUILD
 SYMROOT=$(VERSDIR)/BUILD
+DSTROOT=$(VERSDIR)/BUILD
 
 DIR=KERNEL
 SUBDIR=	src conf
@@ -49,4 +50,5 @@ $(DSTROOT):
 #
 # Include file for directory makefiles
 #
-findfile MakeInc.dir
+# Use GNU make's include directive for compatibility with non-NeXT build tools.
+include MakeInc.dir

--- a/conf/tools/Makefile
+++ b/conf/tools/Makefile
@@ -34,7 +34,8 @@ DSTROOT=$(VERSDIR)/BUILD
 #
 # Include file for directory makefiles
 #
-findfile MakeInc.dir
+# Use GNU make's include directive for compatibility with modern environments.
+include ../../MakeInc.dir
 
 #
 # Get a usable version of doconf for the installhdrs target.

--- a/conf/tools/doconf/Makefile
+++ b/conf/tools/doconf/Makefile
@@ -62,4 +62,5 @@ installhdrs:
 #
 # Include file for shell script makefiles
 #
-findfile MakeInc.csh
+# Use GNU make's include directive for compatibility with modern environments.
+include ../../../MakeInc.csh

--- a/conf/tools/newvers/Makefile
+++ b/conf/tools/newvers/Makefile
@@ -62,4 +62,5 @@ installhdrs:
 #
 # Include file for shell script makefiles
 #
-findfile MakeInc.csh
+# Use GNU make's include directive for compatibility with modern environments.
+include ../../../MakeInc.csh

--- a/relpath
+++ b/relpath
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Compute relative paths akin to NeXT's relpath utility."""
+import argparse, os, sys
+
+def main():
+    parser = argparse.ArgumentParser(description='Compute relative paths.')
+    parser.add_argument('-d', dest='base', required=False, help='Base directory', default=None)
+    parser.add_argument('from_path', nargs='?', default='.')
+    parser.add_argument('to_path', nargs='?', default='.')
+    args = parser.parse_args()
+    base = args.base or os.getcwd()
+    from_abs = os.path.join(base, args.from_path)
+    to_abs = os.path.join(base, args.to_path)
+    rel = os.path.relpath(to_abs, start=from_abs)
+    sys.stdout.write(rel)
+
+if __name__ == '__main__':
+    main()

--- a/src/MAKEDEV/Makefile
+++ b/src/MAKEDEV/Makefile
@@ -75,4 +75,5 @@ installhdrs:
 #
 # Include file for shell script makefiles
 #
-findfile MakeInc.csh
+# Use GNU make's include directive for compatibility with modern environments.
+include ../../MakeInc.csh

--- a/src/Makefile
+++ b/src/Makefile
@@ -43,4 +43,5 @@ SYMROOT=$(VERSDIR)/BUILD
 #
 # Include file for directory makefiles
 #
-findfile MakeInc.dir
+# Use GNU make's include directive for compatibility with modern toolchains.
+include ../MakeInc.dir

--- a/vers_string
+++ b/vers_string
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+# Simple version string generator for legacy build tools.
+prog="$1"
+if [ -z "$prog" ]; then
+  echo "unknown"; exit 0; fi
+# Emit minimal identifier; original tool recorded build info.
+printf '%s 1.0\n' "$prog"


### PR DESCRIPTION
## Summary
- Replace NeXT-specific `findfile` statements with portable GNU `include` directives across build scripts.
- Default DSTROOT and export build-root PATH to surface helper scripts.
- Provide `relpath` and `vers_string` utilities to satisfy legacy build expectations.

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y ed`
- `make kernels` *(fails: ../BUILD/doconf: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689da202c98483319c92009312c818fa